### PR TITLE
Update common config of 'autopep8' and 'Pylint'

### DIFF
--- a/user_info/pyproject.toml
+++ b/user_info/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.autopep8]
+exclude = '__pycache__'
 aggressive = 2
 recursive = true
 diff = true
 exit-code = true
 
-[tool.pylint]
+[tool.pylint.'MAIN']
 recursive = true
+
+[tool.pylint.'MESSAGES CONTROL']
+disable = ['R', 'C']


### PR DESCRIPTION
Only disable 'Refactor' and 'Convention' messages within Pylint.